### PR TITLE
Remove redundant category listener call

### DIFF
--- a/js/blogs.js
+++ b/js/blogs.js
@@ -40,11 +40,9 @@ class BlogManager {
     this.currentFilters.language = newLang; // Update the language filter
     this.currentPage = 1; // Reset to first page on language change
     this.applyFilters(); // Re-apply filters to refresh posts based on new language
-    // Re-attach category listeners as the DOM might have been rebuilt by BlogCategoriesLoader
-    // setTimeout is a small workaround to ensure BlogCategoriesLoader completes its rebuild first
+    // Wait briefly to ensure BlogCategoriesLoader has rebuilt the category tags
     setTimeout(() => {
         if (window.blogCategoriesLoader) {
-            window.blogCategoriesLoader.attachCategoryListeners(); // Re-attach listeners for category tags
             // Ensure the 'All' category for the new language is active by default
             const activeCategoryButton = document.querySelector(`.category-tag[data-slug="all"][data-language="${newLang}"]`);
             if (activeCategoryButton) {


### PR DESCRIPTION
## Summary
- Remove call to nonexistent `attachCategoryListeners` in `BlogManager.handleLanguageChange`
- Ensure active 'All' category is set after language change without extra re-bind logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896c5315748832aa3173b26aaa80407