### PR TITLE
feat: silence console in production

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -173,6 +173,7 @@
   </button>
 
   <!-- Scripts -->
+  <script src="js/dev-mode.js"></script>
   <script src="js/translation-loader.js"></script>
   <script src="js/component-loader.js"></script>
   <script src="js/blog-config.js"></script>

--- a/blogs.html
+++ b/blogs.html
@@ -226,6 +226,7 @@
   </button>
 
   <!-- Scripts -->
+  <script src="js/dev-mode.js"></script>
   <script src="js/translation-loader.js"></script>
   <script src="js/component-loader.js"></script>
   <script src="js/blog-config.js"></script>

--- a/index.html
+++ b/index.html
@@ -760,6 +760,7 @@
 
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
+  <script src="js/dev-mode.js"></script>
   <script src="js/translation-loader.js"></script>
   <script src="js/component-loader.js"></script>
   <script src="js/cookies.js"></script>

--- a/js/dev-mode.js
+++ b/js/dev-mode.js
@@ -1,0 +1,13 @@
+(function() {
+  const devHostnames = ['localhost', '127.0.0.1'];
+  const isDev = devHostnames.includes(window.location.hostname);
+  if (!isDev) {
+    const noop = () => {};
+    ['log', 'info', 'warn', 'error', 'debug'].forEach(method => {
+      if (typeof console[method] === 'function') {
+        console[method] = noop;
+      }
+    });
+  }
+  window.IS_DEV = isDev;
+})();


### PR DESCRIPTION
## Summary
- add development mode script to disable console output in production
- load dev script before other JS across pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896c5454040832a83173350252af044